### PR TITLE
Guard /generate endpoint with API_KEY check

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ cd LLaVA-NeXT
 ```
 
 #### 2. **Install the inference package:**
+Note: Linux environment is recommended. Some packages may not be available in mac os. 
+
 ```bash
 conda create -n llava python=3.10 -y
 conda activate llava
@@ -146,6 +148,14 @@ Checkout the HTTP Post/Get and SRT usage at [sglang/examples/runtime/llava_onevi
     bash examples/usage/llava_video/srt_example_llava_v.sh K K-1 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
     ```
 
+## FastAPI Server
+
+If you wish to run just the server, run the following commands. (TODO: some package versions may conflict with dependencies for training. Resolve)
+
+```sh
+pip install -e ".[api]"
+fastapi dev vessl.py
+```
 
 ## Citation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ train = [
     "tflite-runtime",
 ]
 
+api = [
+    "fastapi[standard]",
+    "torch[standard]"
+]
+
 [project.urls]
 "Homepage" = "https://llava-vl.github.io"
 "Bug Tracker" = "https://github.com/haotian-liu/LLaVA/issues"

--- a/vessl.py
+++ b/vessl.py
@@ -45,19 +45,12 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-@app.post("/v2/generate")
+@app.post("/generate")
 async def generate(
     request: GenerateRequest,
     _: str = Depends(verify_api_key)):
 
     embeddings = request.embeddings # TODO: support response_type = hexadecimal | vector
-    conversation = request.conversation
-    return await run_inference(embeddings, conversation)
-
-@app.post("/generate")
-async def generate(request: GenerateRequest):
-    # Access embeddings and conversation from the request
-    embeddings = request.embeddings
     conversation = request.conversation
     return await run_inference(embeddings, conversation)
 


### PR DESCRIPTION
- guard existing endpoint (`/generate`) with API_KEY check. 
- Note that environment API_KEY needs to be set beforhand (e.g. `export API_KEY='...'` in bash profile) 